### PR TITLE
Added restrict-properties to COOP

### DIFF
--- a/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
+++ b/files/en-us/web/http/headers/cross-origin-opener-policy/index.md
@@ -32,6 +32,7 @@ If a cross-origin document with COOP is opened in a new window, the opening docu
 Cross-Origin-Opener-Policy: unsafe-none
 Cross-Origin-Opener-Policy: same-origin-allow-popups
 Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Opener-Policy: restrict-properties
 ```
 
 ### Directives
@@ -42,6 +43,8 @@ Cross-Origin-Opener-Policy: same-origin
   - : Retains references to newly opened windows or tabs that either don't set COOP or that opt out of isolation by setting a COOP of `unsafe-none`.
 - `same-origin`
   - : Isolates the browsing context exclusively to same-origin documents. Cross-origin documents are not loaded in the same browsing context.
+- `restrict-properties`
+  - : Isolates the opener from the openee (popup), but allows communication between these windows via `window.postMessage()` and `window.closed`.
 
 ## Examples
 


### PR DESCRIPTION
NOTE: 
* I haven't found a way to mark this property as being available in Chrome only for now. Let me know if there's a way.
* This is only available as an origin trial

### Description

Added the new experimental `restrict-properties` value for `COOP`: https://developer.chrome.com/blog/coop-restrict-properties/

### Motivation

`restrict-properties` unlocks cross-origin isolation and XS-Leaks protection for SSO, payments, and other use case that typically rely on popups.

### Additional details

* Chrome blogpost: https://developer.chrome.com/blog/coop-restrict-properties/
* Feature: https://chromestatus.com/feature/5072630953017344

### Related issues and pull requests

None
